### PR TITLE
Implement -r / --require (#15)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+## [v2.0.0]
+> May 27, 2016
+
+- #15 - Implement `-r` / `--require` to support preprocessors like Babel. (#26)
+- Implement `-1` / `--once` to supress watching/rerunning behavior. (#26)
+- __Breaking:__ `--refresh` is now `-R`, from what used to be `-r`.
+
+[v2.0.0]: https://github.com/rstacruz/tape-watch/compare/v1.3.0...v2.0.0
+
 ## [v1.3.0]
 > Jan 15, 2016
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
   -o, --out CMD             output to this file/cmd
   -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed
   -r, --require PACKAGE     require a PACKAGE before startup
+  -1, --once                only run once
 
 Other options:
   -h, --help                show usage information

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Usage:
 Options:
   -p, --pipe PACKAGE        pipe to this package
   -o, --out CMD             output to this file/cmd
-  -r, --refresh PACKAGE     ensure this PACKAGE gets refreshed
+  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed
 
 Other options:
   -h, --help                show usage information

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
   -p, --pipe PACKAGE        pipe to this package
   -o, --out CMD             output to this file/cmd
   -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed
+  -r, --require PACKAGE     require a PACKAGE before startup
 
 Other options:
   -h, --help                show usage information
@@ -41,6 +42,27 @@ Examples:
 
   # ensure require('jquery') and require('react') always gets reevaluated
   tape-watch test/index.js -r jquery -r react
+```
+
+## Using with Babel
+
+Use the `-r` *(--require)* flag with [babel-register](https://www.npmjs.com/package/babel-register).
+
+```sh
+tape-watch -r babel-register
+```
+
+Before you do this, of course, you'll need to install the requisite modules first.
+
+```sh
+npm install --save-dev babel-register babel-preset-es2015
+```
+
+```js
+/* package.json */
+  "babel": {
+    "presets": ["es2015"]
+  }
 ```
 
 ## Thanks

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -17,6 +17,7 @@ var cli = require('meow')([
   '  -o, --out CMD             output to this file/cmd',
   '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
   '  -r, --require PACKAGE     require a PACKAGE before startup',
+  '  -n, --no-watch            only run once',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -141,7 +142,7 @@ function requireMany (modules) {
   if (!Array.isArray(modules)) modules = [modules]
   modules.forEach(function (mod) {
     debug('require', mod)
-    require(mod)
+    requireHere(mod)
   })
 }
 

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -41,6 +41,12 @@ var filename = cli.input[0]
 var cwd = process.cwd()
 process.argv = cli.input.slice(1)
 
+if (!filename) {
+  console.error('Usage: tape-watch <filename>')
+  console.error('See `tape-watch --help` for more options.')
+  process.exit(1)
+}
+
 var report = debounce(mutex(function (files) {
   debug('start', files.map(function (file) { return file[0] }))
 

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -54,14 +54,8 @@ if (cli.flags.require) {
   requireMany(cli.flags.require)
 }
 
-var report = debounce(mutex(report_), 25)
-  
-/*
- * Invokes and reports.
- */
-
-function report_ (files) {
-  debug('start', files.map(function (file) { return file[0] }))
+var report = debounce(mutex(function (files) {
+  debug('start', files && files.map(function (file) { return file[0] }))
 
   return invoke()
     .then(function (ok) {
@@ -78,20 +72,19 @@ function report_ (files) {
     .then(function () {
       debug('listening again')
     })
-}
+}), 25)
 
 /*
  * invoke the test. installs a tape hook to listen for when tests finish.
  */
 
-var invoke = function () {
+var invoke = function (options) {
   return new Promise (function (resolve, reject) {
     flush()
     var stream = tape().createStream()
 
     if (cli.flags.pipe) {
-      stream = stream.pipe(
-        requireHere(cli.flags.pipe)())
+      stream = stream.pipe(requireHere(cli.flags.pipe)())
     }
 
     if (cli.flags.out) {
@@ -101,7 +94,9 @@ var invoke = function () {
     stream.pipe(process.stdout)
     tape().onFinish(once(function () {
       debug('tape finished')
-      tape().getHarness().close()
+      if (!options || !options.noClose) {
+        try { tape().getHarness().close() } catch (e) {}
+      }
       resolve()
     }))
     debug('requiring')
@@ -173,12 +168,17 @@ function requireMany (modules) {
 if (cli.flags.once) {
   process.on('uncaughtException', function (err) {
     console.error(err.stack || err.message || err)
-    process.exit(1)
+    process.exit(2)
   })
 
-  report_([])
-    .then(function () { process.exit(0) })
-    .catch(function () { process.exit(1) })
+  invoke({ noClose: true })
+    .then(function () {
+      process.exit(0)
+    })
+    .catch(function (err) {
+      console.error(err.stack || err.message || err)
+      process.exit(1)
+    })
 } else {
   process.on('uncaughtException', function (err) {
     console.error(err.stack || err.message || err)

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -17,7 +17,7 @@ var cli = require('meow')([
   '  -o, --out CMD             output to this file/cmd',
   '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
   '  -r, --require PACKAGE     require a PACKAGE before startup',
-  '  -n, --no-watch            only run once',
+  '  -1, --once                only run once',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -31,12 +31,12 @@ var cli = require('meow')([
   '  # ensure require("jquery") always gets reevaluated',
   '  tape-watch test/index.js -R jquery',
 ].join('\n'), {
-  boolean: ['help', 'version'],
+  boolean: ['help', 'version', 'once'],
   string: ['pipe', 'out', 'refresh', 'require'],
   '--': true,
   alias: {
     h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh',
-    r: 'require'
+    r: 'require', 1: 'once'
   }
 })
 
@@ -54,7 +54,13 @@ if (cli.flags.require) {
   requireMany(cli.flags.require)
 }
 
-var report = debounce(mutex(function (files) {
+var report = debounce(mutex(report_), 25)
+  
+/*
+ * Invokes and reports.
+ */
+
+function report_ (files) {
   debug('start', files.map(function (file) { return file[0] }))
 
   return invoke()
@@ -72,7 +78,7 @@ var report = debounce(mutex(function (files) {
     .then(function () {
       debug('listening again')
     })
-}), 25)
+}
 
 /*
  * invoke the test. installs a tape hook to listen for when tests finish.
@@ -104,17 +110,25 @@ var invoke = function () {
   })
 }
 
+/*
+ * Requires a package relative to the project dir.
+ */
+
 function requireHere (pkg) {
   return require(path.join(cwd, 'node_modules', pkg))
 }
+
+/*
+ * Returns the `tape` module as the project sees it.
+ */
 
 function tape () {
   return requireHere('tape')
 }
 
 /*
- * delete require cache for any app code (non-modules) and tape itself.
- * we need to clear out tape so that its state is reset.
+ * Delete require cache for any app code (non-modules) and tape itself.
+ * We need to clear out tape so that its state is reset.
  */
 
 function flush () {
@@ -138,25 +152,46 @@ function toArray (list) {
   return Array.isArray(list) ? list : [ list ]
 }
 
+/*
+ * Requires many modules at once.
+ *
+ *     requireMany(['babel-register', 'coffee-script/register'])
+ *     requireMany('babel-register')
+ */
+
 function requireMany (modules) {
-  if (!Array.isArray(modules)) modules = [modules]
-  modules.forEach(function (mod) {
+  toArray(modules).forEach(function (mod) {
     debug('require', mod)
     requireHere(mod)
   })
 }
 
-process.on('uncaughtException', function (err) {
-  console.error(err.stack || err.message || err)
-})
+/*
+ * Run
+ */
 
-var watcher = chokidar.watch('.', {
-  ignored: /[\/\\]\.|node_modules/,
-  persistent: true,
-  ignoreInitial: true
-})
+if (cli.flags.once) {
+  process.on('uncaughtException', function (err) {
+    console.error(err.stack || err.message || err)
+    process.exit(1)
+  })
 
-watcher.on('change', report)
-watcher.on('add', report)
-watcher.on('unlink', report)
-report()
+  report_([])
+    .then(function () { process.exit(0) })
+    .catch(function () { process.exit(1) })
+} else {
+  process.on('uncaughtException', function (err) {
+    console.error(err.stack || err.message || err)
+  })
+
+  var watcher = chokidar.watch('.', {
+    ignored: /[\/\\]\.|node_modules/,
+    persistent: true,
+    ignoreInitial: true
+  })
+
+  watcher.on('change', report)
+  watcher.on('add', report)
+  watcher.on('unlink', report)
+  report()
+}

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -15,7 +15,7 @@ var cli = require('meow')([
   'Options:',
   '  -p, --pipe PACKAGE        pipe to this package',
   '  -o, --out CMD             output to this file/cmd',
-  '  -r, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
+  '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -27,13 +27,13 @@ var cli = require('meow')([
   '  tape-watch test/index.js -o "| tap-spec --color"',
   '',
   '  # ensure require("jquery") always gets reevaluated',
-  '  tape-watch test/index.js -r jquery',
+  '  tape-watch test/index.js -R jquery',
 ].join('\n'), {
   boolean: ['help', 'version'],
   string: ['pipe', 'out', 'refresh'],
   '--': true,
   alias: {
-    h: 'help', v: 'version', p: 'pipe', o: 'out', r: 'refresh'
+    h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh'
   }
 })
 

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -17,7 +17,6 @@ var cli = require('meow')([
   '  -o, --out CMD             output to this file/cmd',
   '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
   '  -r, --require PACKAGE     require a PACKAGE before startup',
-  '  -1, --once                only run once',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -31,12 +30,12 @@ var cli = require('meow')([
   '  # ensure require("jquery") always gets reevaluated',
   '  tape-watch test/index.js -R jquery',
 ].join('\n'), {
-  boolean: ['help', 'version', 'once'],
+  boolean: ['help', 'version'],
   string: ['pipe', 'out', 'refresh', 'require'],
   '--': true,
   alias: {
     h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh',
-    r: 'require', 1: 'once'
+    r: 'require'
   }
 })
 
@@ -94,9 +93,7 @@ var invoke = function (options) {
     stream.pipe(process.stdout)
     tape().onFinish(once(function () {
       debug('tape finished')
-      if (!options || !options.noClose) {
-        try { tape().getHarness().close() } catch (e) {}
-      }
+      try { tape().getHarness().close() } catch (e) {}
       resolve()
     }))
     debug('requiring')
@@ -165,33 +162,17 @@ function requireMany (modules) {
  * Run
  */
 
-if (cli.flags.once) {
-  process.on('uncaughtException', function (err) {
-    console.error(err.stack || err.message || err)
-    process.exit(2)
-  })
+process.on('uncaughtException', function (err) {
+  console.error(err.stack || err.message || err)
+})
 
-  invoke({ noClose: true })
-    .then(function () {
-      process.exit(0)
-    })
-    .catch(function (err) {
-      console.error(err.stack || err.message || err)
-      process.exit(1)
-    })
-} else {
-  process.on('uncaughtException', function (err) {
-    console.error(err.stack || err.message || err)
-  })
+var watcher = chokidar.watch('.', {
+  ignored: /[\/\\]\.|node_modules/,
+  persistent: true,
+  ignoreInitial: true
+})
 
-  var watcher = chokidar.watch('.', {
-    ignored: /[\/\\]\.|node_modules/,
-    persistent: true,
-    ignoreInitial: true
-  })
-
-  watcher.on('change', report)
-  watcher.on('add', report)
-  watcher.on('unlink', report)
-  report()
-}
+watcher.on('change', report)
+watcher.on('add', report)
+watcher.on('unlink', report)
+report()

--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -16,6 +16,7 @@ var cli = require('meow')([
   '  -p, --pipe PACKAGE        pipe to this package',
   '  -o, --out CMD             output to this file/cmd',
   '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
+  '  -r, --require PACKAGE     require a PACKAGE before startup',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -30,10 +31,11 @@ var cli = require('meow')([
   '  tape-watch test/index.js -R jquery',
 ].join('\n'), {
   boolean: ['help', 'version'],
-  string: ['pipe', 'out', 'refresh'],
+  string: ['pipe', 'out', 'refresh', 'require'],
   '--': true,
   alias: {
-    h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh'
+    h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh',
+    r: 'require'
   }
 })
 
@@ -45,6 +47,10 @@ if (!filename) {
   console.error('Usage: tape-watch <filename>')
   console.error('See `tape-watch --help` for more options.')
   process.exit(1)
+}
+
+if (cli.flags.require) {
+  requireMany(cli.flags.require)
 }
 
 var report = debounce(mutex(function (files) {
@@ -129,6 +135,14 @@ function flush () {
 function toArray (list) {
   if (!list) return []
   return Array.isArray(list) ? list : [ list ]
+}
+
+function requireMany (modules) {
+  if (!Array.isArray(modules)) modules = [modules]
+  modules.forEach(function (mod) {
+    debug('require', mod)
+    require(mod)
+  })
 }
 
 process.on('uncaughtException', function (err) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "git+https://github.com/rstacruz/tape-watch.git"
   },
   "scripts": {
-    "test": "node test.js",
-    "test:watch": "./bin/tape-watch -r babel-require test.js"
+    "test": "./bin/tape-watch -r babel-register -1 test.js",
+    "test:watch": "./bin/tape-watch -r babel-register test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "description": "Reruns tape tests when files change",
   "version": "1.3.0",
   "author": "Rico Sta. Cruz <rico@ricostacruz.com>",
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
   "bin": {
     "tape-watch": "bin/tape-watch"
   },
@@ -19,6 +24,8 @@
     "simpler-debounce": "1.0.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "6.9.0",
+    "babel-register": "6.9.0",
     "standard": "6.0.8",
     "tape": "4.4.0",
     "tape-standard": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "git+https://github.com/rstacruz/tape-watch.git"
   },
   "scripts": {
-    "test": "./bin/tape-watch -r babel-register -1 test.js",
+    "test": "tape -r babel-register test.js",
     "test:watch": "./bin/tape-watch -r babel-register test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "url": "git+https://github.com/rstacruz/tape-watch.git"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "test:watch": "./bin/tape-watch -r babel-require test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/rstacruz/tape-watch/issues"
   },
   "dependencies": {
-    "chokidar": "1.5.0",
+    "chokidar": "1.5.1",
     "debounce-collect": "1.0.2",
     "debug": "2.2.0",
     "meow": "3.7.0",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "babel-preset-es2015": "6.9.0",
     "babel-register": "6.9.0",
-    "standard": "6.0.8",
-    "tape": "4.4.0",
+    "standard": "7.1.1",
+    "tape": "4.5.1",
     "tape-standard": "1.1.0"
   },
   "homepage": "https://github.com/rstacruz/tape-watch#readme",


### PR DESCRIPTION
This adds `-r` / `--require`, which allows you to use preprocessors like Babel:

```
tape-watch -r babel-register test.js
```

See #15.