### PR TITLE
Revert "Remove --once support"

### DIFF
--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -17,6 +17,7 @@ var cli = require('meow')([
   '  -o, --out CMD             output to this file/cmd',
   '  -R, --refresh PACKAGE     ensure this PACKAGE gets refreshed',
   '  -r, --require PACKAGE     require a PACKAGE before startup',
+  '  -1, --once                only run once',
   '',
   'Other options:',
   '  -h, --help                show usage information',
@@ -25,12 +26,12 @@ var cli = require('meow')([
   'For examples and docs, see:',
   '  ' + require('../package.json').homepage
 ].join('\n'), {
-  boolean: ['help', 'version'],
+  boolean: ['help', 'version', 'once'],
   string: ['pipe', 'out', 'refresh', 'require'],
   '--': true,
   alias: {
     h: 'help', v: 'version', p: 'pipe', o: 'out', R: 'refresh',
-    r: 'require'
+    r: 'require', 1: 'once'
   }
 })
 
@@ -88,7 +89,9 @@ var invoke = function (options) {
     stream.pipe(process.stdout)
     tape().onFinish(once(function () {
       debug('tape finished')
-      try { tape().getHarness().close() } catch (e) {}
+      if (!options || !options.noClose) {
+        try { tape().getHarness().close() } catch (e) {}
+      }
       resolve()
     }))
 
@@ -164,17 +167,33 @@ function requireMany (modules) {
  * Run
  */
 
-process.on('uncaughtException', function (err) {
-  console.error(err.stack || err.message || err)
-})
+if (cli.flags.once) {
+  process.on('uncaughtException', function (err) {
+    console.error(err.stack || err.message || err)
+    process.exit(2)
+  })
 
-var watcher = chokidar.watch('.', {
-  ignored: /[\/\\]\.|node_modules/,
-  persistent: true,
-  ignoreInitial: true
-})
+  invoke({ noClose: true })
+    .then(function () {
+      process.exit(0)
+    })
+    .catch(function (err) {
+      console.error(err.stack || err.message || err)
+      process.exit(1)
+    })
+} else {
+  process.on('uncaughtException', function (err) {
+    console.error(err.stack || err.message || err)
+  })
 
-watcher.on('change', report)
-watcher.on('add', report)
-watcher.on('unlink', report)
-report()
+  var watcher = chokidar.watch('.', {
+    ignored: /[\/\\]\.|node_modules/,
+    persistent: true,
+    ignoreInitial: true
+  })
+
+  watcher.on('change', report)
+  watcher.on('add', report)
+  watcher.on('unlink', report)
+  report()
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "git+https://github.com/rstacruz/tape-watch.git"
   },
   "scripts": {
-    "test": "tape -r babel-register test.js",
+    "test": "./bin/tape-watch -r babel-register -1 test.js",
     "test:watch": "./bin/tape-watch -r babel-register test.js",
     "lint": "eslint-check"
   }


### PR DESCRIPTION
This is actually better than the tape executable because it actually exits the process lol

`tape`, for me at least, using `blue-tape`, hangs after the tests are finished.
