### PR TITLE
Make glob synchronous to fix `**/*.js` not working

### DIFF
--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -6,7 +6,7 @@ var once = require('once')
 var debug = require('debug')('tape-watch')
 var mutex = require('../lib/mutex')
 var wait = require('../lib/wait')
-var glob = require('thenify')(require('glob'))
+var glob = require('glob')
 
 var cli = require('meow')([
   'Usage:',
@@ -92,15 +92,13 @@ var invoke = function (options) {
       resolve()
     }))
 
-    Promise.all(toArray(filenames).map(function (spec) {
-      return glob(spec).then(function (files) {
-        files.forEach(function (fname) {
-          debug('requiring', fname)
-          require(path.join(cwd, fname))
-        })
+    toArray(filenames).map(function (spec) {
+      const files = glob.sync(spec)
+      files.forEach(function (fname) {
+        debug('requiring', fname)
+        require(path.join(cwd, fname))
       })
-    }))
-    .catch(reject)
+    })
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "meow": "3.7.0",
     "once": "1.3.3",
     "outpipe": "1.1.1",
-    "simpler-debounce": "1.0.0",
-    "thenify": "3.2.0"
+    "simpler-debounce": "1.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.9.0",


### PR DESCRIPTION
I think globs are working by accident. If you [prevent the command line from expanding \*\*/\*](http://stackoverflow.com/questions/32017169/npm-glob-pattern-not-matching-subdirectories), `glob()` doesn't return any files. Applied a quick fix here by making glob synchronous. Doesn't look like a particularly expensive operation.