### PR TITLE
Support absolute paths

### DIFF
--- a/bin/tape-watch
+++ b/bin/tape-watch
@@ -100,7 +100,7 @@ var invoke = function (options) {
       const files = glob.sync(spec)
       files.forEach(function (fname) {
         debug('requiring', fname)
-        require(path.join(cwd, fname))
+        require(path.resolve(cwd, fname))
       })
     })
   })


### PR DESCRIPTION
Most editors let you right click a file and get the absolute path. This lets you quickly do something like `tape-watch <paste file here>`

Just had to switch path.join to path.resolve--still works the old way with relative paths.